### PR TITLE
Add support for Rails 6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,3 @@
 source 'https://rubygems.org'
 
-gem 'actionpack', '~> 5.0'
-gem 'activesupport', '~> 5.0'
-gem 'minitest', '~> 5.0'
-gem 'mustache', '~> 1.0'
-gem 'rake', '~> 10.0'
-gem 'rubocop', '~> 0.52', require: false
+gemspec

--- a/fern-documentation.gemspec
+++ b/fern-documentation.gemspec
@@ -18,9 +18,10 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.3.0'
 
   s.add_development_dependency 'minitest', '~> 5.0'
-  s.add_development_dependency 'rake', '~> 10.0'
+  s.add_development_dependency 'rake', '~> 12.0'
+  s.add_development_dependency 'rubocop', '~> 0.74.0'
 
-  s.add_runtime_dependency 'actionpack', '~> 5.0'
-  s.add_runtime_dependency 'activesupport', '~> 5.0'
-  s.add_runtime_dependency 'mustache', '~> 1.0'
+  s.add_runtime_dependency 'actionpack', '>= 5.0'
+  s.add_runtime_dependency 'activesupport', '>= 5.0'
+  s.add_runtime_dependency 'mustache', '~> 1.1'
 end

--- a/lib/fern/documentation/version.rb
+++ b/lib/fern/documentation/version.rb
@@ -1,5 +1,5 @@
 module Fern
   module Documentation
-    VERSION = '0.0.1'.freeze
+    VERSION = '0.0.2'.freeze
   end
 end


### PR DESCRIPTION
Appears the other fern-* projects got updated to support Rails 6 except this one.